### PR TITLE
Improvements to the mk command

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
+build/
 node_modules/
 public/

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,2 @@
-internals/
 node_modules/
 public/

--- a/internals/scripts/mk.js
+++ b/internals/scripts/mk.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /**
  * MK is a minimal generator for constructing components from template files
  * powered by inquirer
@@ -65,7 +66,7 @@ inquirer.prompt(questions).then(function (answers) {
   const runOrDie = (func, error) => {
     if (error) return console.error(error);
     return func();
-  }
+  };
 
   // append an asset filename onto our destination path
   const assetPath = (asset) => `${dest}/${asset}`;

--- a/internals/scripts/mk.js
+++ b/internals/scripts/mk.js
@@ -3,11 +3,11 @@
  * powered by inquirer
  */
 'use strict';
-var fs = require('fs-extra');
-var inquirer = require('inquirer');
+const fs = require('fs-extra');
+const inquirer = require('inquirer');
 
 
-var questions = [
+const questions = [
   {
     type: 'list',
     name: 'template',
@@ -19,7 +19,7 @@ var questions = [
     name: 'name',
     message: 'Name ❯',
     validate: function (value) {
-      var pass = value.match(/^[a-zA-Z0-9_]*$/);
+      const pass = value.match(/^[a-zA-Z0-9_]*$/);
       if (pass) {
         return true;
       }
@@ -41,13 +41,13 @@ var questions = [
 ];
 
 function build(name, description) {
-  var dest = 'src/components/' + name + '/';
-  var component_src = dest + 'index.js';
+  const dest = 'src/components/' + name + '/';
+  const component_src = dest + 'index.js';
   fs.readFile(dest + 'index.js', 'utf8', function (err,data) {
     if (err) {
       return console.log(err);
     }
-    var result = data.replace(/COMPONENT_NAME/g, name).replace(/COMPONENT_DESCRIPTION/g, description);
+    const result = data.replace(/COMPONENT_NAME/g, name).replace(/COMPONENT_DESCRIPTION/g, description);
 
     // another small piece of callback hell that will be resolved
     fs.writeFile(component_src, result, 'utf8', function (err) {
@@ -58,8 +58,8 @@ function build(name, description) {
 }
 
 inquirer.prompt(questions).then(function (answers) {
-  var dest = 'src/components/' + answers.name;
-  var template = 'internals/templates/' + answers.template;
+  const dest = 'src/components/' + answers.name;
+  const template = 'internals/templates/' + answers.template;
 
   // only run the given function if there is no error
   const runOrDie = (func, error) => {

--- a/internals/templates/container.js
+++ b/internals/templates/container.js
@@ -15,7 +15,7 @@ export default class COMPONENT_NAME extends Component {
     super(props);
     this.state = {
       // initialize state here
-    }
+    };
   }
   render() {
     return (

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:serve": " cd build & python -m SimpleHTTPServer 3000",
     "lint": "eslint src/**/*.js",
     "server": "webpack-dev-server --quiet --config webpack.dev.js --host 0.0.0.0 --port 4000",
-    "mk": "node internals/scripts/mk.js",
+    "mk": "babel-node internals/scripts/mk.js",
     "start": "npm-run-all --parallel lint server"
   },
   "repository": {
@@ -60,6 +60,7 @@
     "webpack-manifest-plugin": "^1.1.0"
   },
   "dependencies": {
+    "babel-cli": "^6.18.0",
     "history": "^4.4.0",
     "inferno": "1.0.0-beta32",
     "inferno-component": "1.0.0-beta32",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "rm -rf build & webpack --config webpack.prod.js",
     "build:serve": " cd build & python -m SimpleHTTPServer 3000",
-    "lint": "eslint src/**/*.js",
+    "lint": "eslint ./**/*.js",
     "server": "webpack-dev-server --quiet --config webpack.dev.js --host 0.0.0.0 --port 4000",
     "mk": "babel-node internals/scripts/mk.js",
     "start": "npm-run-all --parallel lint server"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "rm -rf build & webpack --config webpack.prod.js",
     "build:serve": " cd build & python -m SimpleHTTPServer 3000",
-    "lint": "eslint ./**/*.js",
+    "lint": "eslint ./",
     "server": "webpack-dev-server --quiet --config webpack.dev.js --host 0.0.0.0 --port 4000",
     "mk": "babel-node internals/scripts/mk.js",
     "start": "npm-run-all --parallel lint server"

--- a/yarn.lock
+++ b/yarn.lock
@@ -268,6 +268,27 @@ aws4@^1.2.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.5.0.tgz#0a29ffb79c31c9e712eeb087e8e7a64b4a56d755"
 
+babel-cli:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-cli/-/babel-cli-6.18.0.tgz#92117f341add9dead90f6fa7d0a97c0cc08ec186"
+  dependencies:
+    babel-core "^6.18.0"
+    babel-polyfill "^6.16.0"
+    babel-register "^6.18.0"
+    babel-runtime "^6.9.0"
+    commander "^2.8.1"
+    convert-source-map "^1.1.0"
+    fs-readdir-recursive "^1.0.0"
+    glob "^5.0.5"
+    lodash "^4.2.0"
+    output-file-sync "^1.1.0"
+    path-is-absolute "^1.0.0"
+    slash "^1.0.0"
+    source-map "^0.5.0"
+    v8flags "^2.0.10"
+  optionalDependencies:
+    chokidar "^1.0.0"
+
 babel-code-frame@^6.11.0, babel-code-frame@^6.20.0:
   version "6.20.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.20.0.tgz#b968f839090f9a8bc6d41938fb96cb84f7387b26"
@@ -902,6 +923,14 @@ babel-plugin-undefined-to-void@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz#7f578ef8b78dfae6003385d8417a61eda06e2f81"
 
+babel-polyfill@^6.16.0:
+  version "6.20.0"
+  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.20.0.tgz#de4a371006139e20990aac0be367d398331204e7"
+  dependencies:
+    babel-runtime "^6.20.0"
+    core-js "^2.4.0"
+    regenerator-runtime "^0.10.0"
+
 babel-preset-es2015:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.18.0.tgz#b8c70df84ec948c43dcf2bf770e988eb7da88312"
@@ -1287,7 +1316,7 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chokidar@^1.4.3, chokidar@^1.6.0:
+chokidar@^1.0.0, chokidar@^1.4.3, chokidar@^1.6.0:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.6.1.tgz#2f4447ab5e96e50fb3d789fd90d4c72e0e4c70c2"
   dependencies:
@@ -1413,7 +1442,7 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.5.0, commander@^2.9.0, commander@2.9.x:
+commander@^2.5.0, commander@^2.8.1, commander@^2.9.0, commander@2.9.x:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
@@ -2439,6 +2468,10 @@ fs-readdir-recursive@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz#315b4fb8c1ca5b8c47defef319d073dad3568059"
 
+fs-readdir-recursive@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz#8cd1745c8b4f8a29c8caec392476921ba195f560"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -2528,7 +2561,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@^5.0.15, glob@^5.0.3:
+glob@^5.0.15, glob@^5.0.3, glob@^5.0.5:
   version "5.0.15"
   resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
   dependencies:
@@ -5595,6 +5628,12 @@ uuid@^2.0.2:
 uuid@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
+
+v8flags@^2.0.10:
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-2.0.11.tgz#bca8f30f0d6d60612cc2c00641e6962d42ae6881"
+  dependencies:
+    user-home "^1.1.1"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
This PR aims to migrate the `mk` script to modern es6 syntax. It also introduces the main `yarn lint` script into the root project, rather than just the `src/` directory. Which means that all `internals/` will be checked by the linter.